### PR TITLE
fix grpc go test

### DIFF
--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -122,21 +122,21 @@ func testGRPC2Rest(t *testing.T, e engine.Engine) {
 	}()
 	util.Pour("9096")
 
-	port, method := "9096", "pet"
-	response, err := grpc2rest.CallClient(&port, &method, "3")
+	port, method := "9096", "petput"
+	response, err := grpc2rest.CallClient(&port, &method, "123124126,testpet")
 	assert.Nil(t, err)
-	assert.Equal(t, int32(3), response.(*grpc2rest.PetResponse).Pet.Id)
+	assert.Equal(t, int32(123124126), response.(*grpc2rest.PetResponse).Pet.Id)
+	assert.Equal(t, "testpet", response.(*grpc2rest.PetResponse).Pet.Name)
+
+	method = "pet"
+	response, err = grpc2rest.CallClient(&port, &method, "123124126")
+	assert.Nil(t, err)
+	assert.Equal(t, int32(123124126), response.(*grpc2rest.PetResponse).Pet.Id)
 
 	method = "user"
-	response, err = grpc2rest.CallClient(&port, &method, "user3")
+	response, err = grpc2rest.CallClient(&port, &method, "user123124126")
 	assert.Nil(t, err)
-	assert.Equal(t, "user3", response.(*grpc2rest.UserResponse).User.Username)
-
-	method = "petput"
-	response, err = grpc2rest.CallClient(&port, &method, "2,testpet")
-	assert.Nil(t, err)
-	assert.Equal(t, int32(2), response.(*grpc2rest.PetResponse).Pet.Id)
-	assert.Equal(t, "testpet", response.(*grpc2rest.PetResponse).Pet.Name)
+	assert.Equal(t, "user123124126", response.(*grpc2rest.UserResponse).User.Username)
 }
 
 func TestGRPC2RestAPI(t *testing.T) {

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -63,7 +63,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	gateway := microapi.New("petByIdDispatch")
 	service := gateway.NewService("PetStorePets", &rest.Activity{})
 	service.SetDescription("Make calls to find pets")
-	service.AddSetting("uri", "http://petstore.swagger.io/v2/pet/:id")
+	service.AddSetting("uri", "http://localhost:8181/pet/:id")
 	service.AddSetting("method", "GET")
 	step := gateway.NewStep(service)
 	step.AddInput("pathParams.id", "=$.payload.params.Id")
@@ -87,7 +87,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	gateway = microapi.New("petPutDispatch")
 	service = gateway.NewService("PetStorePetsPUT", &rest.Activity{})
 	service.SetDescription("Make calls to petstore")
-	service.AddSetting("uri", "http://petstore.swagger.io/v2/pet")
+	service.AddSetting("uri", "http://localhost:8181/pet")
 	service.AddSetting("method", "PUT")
 	service.AddSetting("headers", map[string]string{"Content-Type": "application/json"})
 	step = gateway.NewStep(service)
@@ -112,7 +112,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	gateway = microapi.New("userByNameDispatch")
 	service = gateway.NewService("PetStoreUsersByName", &rest.Activity{})
 	service.SetDescription("Make calls to find users")
-	service.AddSetting("uri", "http://petstore.swagger.io/v2/user/:username")
+	service.AddSetting("uri", "http://localhost:8181/user/:username")
 	service.AddSetting("method", "GET")
 	step = gateway.NewStep(service)
 	step.AddInput("pathParams.username", "=$.payload.params.Username")
@@ -143,7 +143,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	action := &microgateway.Action{}
 
 	handler, err := trg.NewHandler(&trigger.HandlerSettings{
-		MethodName:      "PetById",
+		MethodName: "PetById",
 	})
 	if err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	}
 
 	handler, err = trg.NewHandler(&trigger.HandlerSettings{
-		MethodName:      "PetPUT",
+		MethodName: "PetPUT",
 	})
 	if err != nil {
 		return nil, err
@@ -165,7 +165,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	}
 
 	handler, err = trg.NewHandler(&trigger.HandlerSettings{
-		MethodName:      "UserByName",
+		MethodName: "UserByName",
 	})
 	if err != nil {
 		return nil, err

--- a/examples/json/grpc-to-rest/flogo.json
+++ b/examples/json/grpc-to-rest/flogo.json
@@ -91,7 +91,7 @@
             "description": "Make calls to find pets",
             "ref": "github.com/project-flogo/contrib/activity/rest",
             "settings": {
-              "uri": "http://petstore.swagger.io/v2/pet/:id",
+              "uri": "http://localhost:8181/pet/:id",
               "method": "GET"
             }
           }
@@ -139,7 +139,7 @@
             "description": "Make calls to petstore",
             "ref": "github.com/project-flogo/contrib/activity/rest",
             "settings": {
-              "uri": "http://petstore.swagger.io/v2/pet",
+              "uri": "http://localhost:8181/pet",
               "method": "PUT",
               "headers": {
                 "Content-Type": "application/json"
@@ -190,7 +190,7 @@
             "description": "Make calls to find users",
             "ref": "github.com/project-flogo/contrib/activity/rest",
             "settings": {
-              "uri": "http://petstore.swagger.io/v2/user/:username",
+              "uri": "http://localhost:8181/user/:username",
               "method": "GET"
             }
           }


### PR DESCRIPTION
This PR fixes #2 

Resolution:
Changed test cases execution order.
Push test case executes first then get test case executed, so that pet will be always available from petstore.