### PR TITLE
removed dependency on petstore for go tests

### DIFF
--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -181,7 +181,7 @@ func TestGRPC2RestAPI(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping API integration test in short mode")
 	}
-	setEndURL("http://localhost:8181")
+	petStoreURL = "http://localhost:8181"
 	e, err := GRPC2RestExample()
 	assert.Nil(t, err)
 	testGRPC2Rest(t, e)

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -11,6 +11,16 @@ import (
 	microapi "github.com/project-flogo/microgateway/api"
 )
 
+var endURL string
+
+func init() {
+	endURL = "http://petstore.swagger.io/v2"
+}
+
+func setEndURL(url string) {
+	endURL = url
+}
+
 func GRPC2GRPCExample() (engine.Engine, error) {
 	app := api.NewApp()
 
@@ -63,7 +73,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	gateway := microapi.New("petByIdDispatch")
 	service := gateway.NewService("PetStorePets", &rest.Activity{})
 	service.SetDescription("Make calls to find pets")
-	service.AddSetting("uri", "http://petstore.swagger.io/v2/pet/:id")
+	service.AddSetting("uri", endURL+"/pet/:id")
 	service.AddSetting("method", "GET")
 	step := gateway.NewStep(service)
 	step.AddInput("pathParams.id", "=$.payload.params.Id")
@@ -87,7 +97,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	gateway = microapi.New("petPutDispatch")
 	service = gateway.NewService("PetStorePetsPUT", &rest.Activity{})
 	service.SetDescription("Make calls to petstore")
-	service.AddSetting("uri", "http://petstore.swagger.io/v2/pet")
+	service.AddSetting("uri", endURL+"/pet")
 	service.AddSetting("method", "PUT")
 	service.AddSetting("headers", map[string]string{"Content-Type": "application/json"})
 	step = gateway.NewStep(service)
@@ -112,7 +122,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	gateway = microapi.New("userByNameDispatch")
 	service = gateway.NewService("PetStoreUsersByName", &rest.Activity{})
 	service.SetDescription("Make calls to find users")
-	service.AddSetting("uri", "http://petstore.swagger.io/v2/user/:username")
+	service.AddSetting("uri", endURL+"/user/:username")
 	service.AddSetting("method", "GET")
 	step = gateway.NewStep(service)
 	step.AddInput("pathParams.username", "=$.payload.params.Username")
@@ -143,7 +153,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	action := &microgateway.Action{}
 
 	handler, err := trg.NewHandler(&trigger.HandlerSettings{
-		MethodName:      "PetById",
+		MethodName: "PetById",
 	})
 	if err != nil {
 		return nil, err
@@ -154,7 +164,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	}
 
 	handler, err = trg.NewHandler(&trigger.HandlerSettings{
-		MethodName:      "PetPUT",
+		MethodName: "PetPUT",
 	})
 	if err != nil {
 		return nil, err
@@ -165,7 +175,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	}
 
 	handler, err = trg.NewHandler(&trigger.HandlerSettings{
-		MethodName:      "UserByName",
+		MethodName: "UserByName",
 	})
 	if err != nil {
 		return nil, err

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -11,15 +11,7 @@ import (
 	microapi "github.com/project-flogo/microgateway/api"
 )
 
-var endURL string
-
-func init() {
-	endURL = "http://petstore.swagger.io/v2"
-}
-
-func setEndURL(url string) {
-	endURL = url
-}
+var petStoreURL = "http://petstore.swagger.io/v2"
 
 func GRPC2GRPCExample() (engine.Engine, error) {
 	app := api.NewApp()
@@ -73,7 +65,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	gateway := microapi.New("petByIdDispatch")
 	service := gateway.NewService("PetStorePets", &rest.Activity{})
 	service.SetDescription("Make calls to find pets")
-	service.AddSetting("uri", endURL+"/pet/:id")
+	service.AddSetting("uri", petStoreURL+"/pet/:id")
 	service.AddSetting("method", "GET")
 	step := gateway.NewStep(service)
 	step.AddInput("pathParams.id", "=$.payload.params.Id")
@@ -97,7 +89,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	gateway = microapi.New("petPutDispatch")
 	service = gateway.NewService("PetStorePetsPUT", &rest.Activity{})
 	service.SetDescription("Make calls to petstore")
-	service.AddSetting("uri", endURL+"/pet")
+	service.AddSetting("uri", petStoreURL+"/pet")
 	service.AddSetting("method", "PUT")
 	service.AddSetting("headers", map[string]string{"Content-Type": "application/json"})
 	step = gateway.NewStep(service)
@@ -122,7 +114,7 @@ func GRPC2RestExample() (engine.Engine, error) {
 	gateway = microapi.New("userByNameDispatch")
 	service = gateway.NewService("PetStoreUsersByName", &rest.Activity{})
 	service.SetDescription("Make calls to find users")
-	service.AddSetting("uri", endURL+"/user/:username")
+	service.AddSetting("uri", petStoreURL+"/user/:username")
 	service.AddSetting("method", "GET")
 	step = gateway.NewStep(service)
 	step.AddInput("pathParams.username", "=$.payload.params.Username")


### PR DESCRIPTION
This PR fixes #2 .

go test is failing because of dependency on petstore. Mock server is used for go tests alone.