### PR TITLE
allow server cert and server key from file picker and app properties

### DIFF
--- a/trigger/grpc/README.md
+++ b/trigger/grpc/README.md
@@ -100,7 +100,7 @@ Following is the example mashling gateway descriptor uses a grpc trigger.
     {
       "name": "flogo-grpc",
       "id": "MyProxy",
-      "ref": "github.com/project-flogo/grpc/trigger",
+      "ref": "github.com/project-flogo/grpc/trigger/grpc",
       "settings": {
         "port": "9096",
         "protoName": "petstore"


### PR DESCRIPTION
In flogo, the server key and server certificate files can be supplied in the following ways:

1. From file picker [FE]
2. Application property with encoded value [FE]
3. Application property with value as path to file on local machine using "file:\\" prefix. [FE]
4. File path as string value [Only in OSS]
5. Application property without any encoding. [FE]

Added support to decode the certificate in each case.