### PR TITLE
fix enum default and app property as "file://"

### DIFF
--- a/trigger/grpc/trigger.go
+++ b/trigger/grpc/trigger.go
@@ -191,7 +191,7 @@ func (t *Trigger) CallHandler(grpcData map[string]interface{}) (int, interface{}
 
 	params := make(map[string]interface{})
 	var content interface{}
-	m := jsonpb.Marshaler{OrigName: true}
+	m := jsonpb.Marshaler{OrigName: true, EmitDefaults: true}
 	// blocking the code for streaming requests
 	if grpcData["contextdata"] != nil {
 		// getting values from inputrequestdata and mapping it to params which can be used in different services like HTTP pathparams etc.
@@ -247,6 +247,7 @@ func (t *Trigger) CallHandler(grpcData map[string]interface{}) (int, interface{}
 		}
 
 		t.Logger.Debug("Dispatch Found for ", handler.settings.ServiceName+"_"+handler.settings.MethodName)
+		t.Logger.Debugf("Calling handler with params: %v", params)
 		results, err := handler.handler.Handle(context.Background(), out)
 		if err != nil {
 			return 0, nil, err
@@ -298,7 +299,7 @@ func (t *Trigger) decodeCertificate(cert string) ([]byte, error) {
 	if strings.HasPrefix(cert, "file://") {
 		// app property pointing to a file
 		t.Logger.Debug("Certificate received from application property pointing to a file")
-		fileName := t.settings.ServerCert[7:]
+		fileName := cert[7:]
 		return ioutil.ReadFile(fileName)
 	}
 


### PR DESCRIPTION
In accordance with issue https://github.com/golang/protobuf/issues/918, if we input a value to enum which is the default value we lose the value when marshaling the input in `trigger.go `
To fix this, adding `EmitDefaults :  true` to the marshaler configuration.

Also, fixing a typo at line 302.